### PR TITLE
Bug fixes and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ In order to test the Python module outside of Ansible, you need to remove the mo
 
 ## How to use
 
-First you need to setup a CA in the specific format these scripts are expecting:
+First you need to setup a CA in the specific format these scripts are expecting.  By default the CA cert will be left intact if it exists.  The `force` option will when set to ***true*** will overwrite the ca.
+
 
 ```yaml
 ---
@@ -35,10 +36,10 @@ To create a certificate, you simply need to reference the CA and provide the ess
 ---
 
 - name: Create a Server Cert
-  certificate: cadir="/etc/certs" hostname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}"
+  certificate: cadir="/etc/certs" certname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}"
 
 - name: Create a Client Cert
-  certificate: cadir="/etc/certs" hostname="client.example.com" subj="/DC=com/DC=example/CN=client/" p12password="{{some_env_var}}" certtype="client"
+  certificate: cadir="/etc/certs" certname="client.example.com" subj="/DC=com/DC=example/CN=client/" p12password="{{some_env_var}}" certtype="client"
 
 ```
 
@@ -46,7 +47,7 @@ Note: the default `certtype` is **server**, so you will need to specify **client
 
 1.  `{{hostname}}.key.pem` - the private key.
 2.  `{{hostname}}.req.pem` - the signing request.
-3.  `{{hostname}}.cert.pem` - the certificate signed by the CA.
+3.  `{{hostname}}.cert.pem.pub` - the certificate signed by the CA.
 4.  `{{hostname}}.keycert.pem` - a file containing both the private key and certificate (we found this necessary for some applications using SSL).
 5.  `{{hostname}}.keycert.p12` - the PKCS12 version of the key + cert pair.
 
@@ -80,16 +81,18 @@ This will cause the CA directory to be deleted (the script doesn't care that it 
 ```yaml
 ---
 
-- name: Create a java keystore 
-  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com" certtype="keystore" src_password='changeit'
-
 ```
+The keytool utility is used for creating truststores and keystores for users and servers.   This requires the certificates have been created with the `certificate` module:
 
 ```yaml
 ---
 
-- name: Create a java trustore and trust the server hosts
+- name: Create a java server trustore and trust the server hosts
   keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com"
+
+- name: Create a java server keystore 
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com" certtype="keystore" src_password='changeit'
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To create a certificate, you simply need to reference the CA and provide the ess
 ---
 
 - name: Create a Server Cert
-  certificate: cadir="/etc/certs" certname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}"
+  certificate: cadir="/etc/certs" certname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}" subjectAltNames="DNS:client,DNS:server.example.com,IP:192.168.2.2"
 
 - name: Create a Client Cert
   certificate: cadir="/etc/certs" certname="client.example.com" subj="/DC=com/DC=example/CN=client/" p12password="{{some_env_var}}" certtype="client"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,22 @@ Deleting the CA functions similarly:
 
 This will cause the CA directory to be deleted (the script doesn't care that it didn't create the directory, so suck it up).
 
-Finally, it's worth mentioning that there is another tool to generate a Java Truststore from an OpenSSL PEM.
+
+```yaml
+---
+
+- name: Create a java keystore 
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com" certtype="keystore" src_password='changeit'
+
+```
+
+```yaml
+---
+
+- name: Create a java trustore and trust the server hosts
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com"
+
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,7 @@ Deleting the CA functions similarly:
 This will cause the CA directory to be deleted (the script doesn't care that it didn't create the directory, so suck it up).
 
 
-```yaml
----
 
-```
 The keytool utility is used for creating truststores and keystores for users and servers.   This requires the certificates have been created with the `certificate` module:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The keytool utility is used for creating truststores and keystores for users and
   keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com"
 
 - name: Create a java server keystore 
-  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com" certtype="keystore" src_password='changeit'
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit'  certtype="keystore" src_password='changeit'
 
 
 ```

--- a/dist/ca
+++ b/dist/ca
@@ -8,6 +8,7 @@ KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
 TMPL_CA_CERT = "openssl req -x509 -config openssl.cnf -newkey rsa:{0} -days {1} -out cacert.pem -outform PEM -subj \"{2}\" -nodes"
 TMPL_CONVERT = "openssl x509 -in cacert.pem -out cacert.cer -outform DER"
+TMPL_CA_HASH = "c_rehash -n {0} "
 DEV_NULL = open('/dev/null', 'w')
 
 OPENSSL_CNF = """
@@ -156,17 +157,9 @@ commonName      = Common Name (eg, your name or your server\'s hostname)
 commonName_max      = 64
 commonName_default    = Fake Org Fake CA - d59341ee
 
-#emailAddress     = Email Address
-#emailAddress_max   = 64
-
 # SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-#challengePassword    = A challenge password
-#challengePassword_min    = 4
-#challengePassword_max    = 20
-#challengePassword_default  = password
-
 unstructuredName    = An optional company name
 
 [ usr_cert ]
@@ -178,24 +171,6 @@ unstructuredName    = An optional company name
 
 basicConstraints=CA:FALSE
 
-# Here are some examples of the usage of nsCertType. If it is omitted
-# the certificate can be used for anything *except* object signing.
-
-# This is OK for an SSL server.
-# nsCertType      = server
-
-# For an object signing certificate this would be used.
-# nsCertType = objsign
-
-# For normal client use this is typical
-# nsCertType = client, email
-
-# and for everything including object signing:
-# nsCertType = client, email, objsign
-
-# This is typical in keyUsage for a client certificate.
-# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-
 # This will be displayed in Netscape's comment listbox.
 nsComment     = "Completely Fake Certificate"
 
@@ -206,19 +181,6 @@ authorityKeyIdentifier=keyid,issuer:always
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
 subjectAltName=email:copy
-# An alternative to produce certificates that aren't
-# deprecated according to PKIX.
-# subjectAltName=email:move
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
 
 [ v3_req ]
 
@@ -246,25 +208,6 @@ authorityKeyIdentifier=keyid:always,issuer:always
 # So we do this instead.
 basicConstraints = CA:true
 
-# Key usage: this is typical for a CA certificate. However since it will
-# prevent it being used as an test self-signed certificate it is best
-# left out by default.
-# keyUsage = cRLSign, keyCertSign
-
-# Some might want this also
-# nsCertType = sslCA, emailCA
-
-# Include email address in subject alt name: another PKIX recommendation
-# subjectAltName=email:copy
-# Copy issuer details
-# issuerAltName=issuer:copy
-
-# DER hex encoding of an extension: beware experts only!
-# obj=DER:02:03
-# Where 'obj' is a standard or added object
-# You can even override a supported extension:
-# basicConstraints= critical, DER:30:03:01:01:FF
-
 [ crl_ext ]
 
 # CRL extensions.
@@ -282,57 +225,22 @@ authorityKeyIdentifier=keyid:always,issuer:always
 
 basicConstraints=CA:FALSE
 
-# Here are some examples of the usage of nsCertType. If it is omitted
-# the certificate can be used for anything *except* object signing.
-
-# This is OK for an SSL server.
-#nsCertType                     = server
-
-# For an object signing certificate this would be used.
-# nsCertType = objsign
-
 # For normal client use this is typical
 nsCertType = client, email
-# nsCertType = client
-
-# and for everything including object signing:
-#nsCertType = server, client, email, objsign
 
 # This is typical in keyUsage for a client certificate.
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
-#nsComment                      = "Test Certificate"
-
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
-
-# This stuff is for subjectAltName and issuerAltname.
-# Import the email address.
-# subjectAltName=email:copy
-# An alternative to produce certificates that aren't
-# deprecated according to PKIX.
-# subjectAltName=email:move
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl              = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
-
-
 
 """
 
 class CA:
 
     def __init__(self, cadir, subj, force):
-        self.cadir = self.normalize_directory_path(cadir)
+        self.cadir = os.path.realpath(self.normalize_directory_path(cadir))
         self.subj = subj
         self.force = force
 
@@ -425,6 +333,10 @@ class CA:
         if not os.path.exists(fileCaCert):
             cmd = TMPL_CA_CERT.format(KEY_STRENGTH, DAYS_VALID, self.subj)
             self.execute_command(cmd)
+
+            cmd = TMPL_CA_HASH.format(self.cadir)
+            self.execute_command(cmd)
+
             changes.append("Created CA certificate.")
             changed = True
 

--- a/dist/ca
+++ b/dist/ca
@@ -1,6 +1,44 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+
+DOCUMENTATION = '''
+---
+module: ca
+short_description: Manages CA certificates
+description:
+    - Create, update, and delete for a CA
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  certdir:
+    description:
+      - The directory to store the certificate
+    required: true
+  subj:
+    description:
+      - The CA subject
+    required: true
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  force:
+    description:
+      - This will overwrite the CA
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+
+- name: Setup a CA
+  ca: certdir="/etc/certs" subj="/DC=com/DC=example/CN=CA/"
+- name: Remove a CA
+  ca: certdir="/etc/certs" subj="/CN=whatever/" state="absent"
+'''
+
 import os, shutil
 from subprocess import call
 

--- a/dist/ca
+++ b/dist/ca
@@ -18,109 +18,101 @@ OPENSSL_CNF = """
 
 # This definition stops the following lines choking if HOME isn't
 # defined.
-HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+HOME      = .
+RANDFILE    = $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
-#oid_file		= $ENV::HOME/.oid
-oid_section		= new_oids
+#oid_file   = $ENV::HOME/.oid
+oid_section   = new_oids
+
 
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
 # X.509v3 extensions to use:
-# extensions		= 
+# extensions    = 
 # (Alternatively, use a configuration file that has only
 # X.509v3 extensions in its main [= default] section.)
 
 [ new_oids ]
 
-# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# We can add new OIDs in here for use by 'ca' and 'req'.
 # Add a simple OID like this:
 # testoid1=1.2.3.4
 # Or use config file substitution like this:
 
-# Policies used by the TSA examples.
-tsa_policy1 = 1.2.3.4.1
-tsa_policy2 = 1.2.3.4.5.6
-tsa_policy3 = 1.2.3.4.5.7
-
 ####################################################################
 [ ca ]
-default_ca	= CA_default		# The default ca section
+default_ca  = CA_default    # The default ca section
 
 ####################################################################
 [ CA_default ]
 
-dir		= {0} 			# Where everything is kept
-certs		= $dir/certs		# Where the issued certs are kept
-crl_dir		= $dir/crl		# Where the issued crl are kept
-database	= $dir/index.txt	# database index file.
-#unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
-new_certs_dir	= $dir/newcerts		# default place for new certs.
+dir             = {0}                   # Where everything is kept
+certs           = $dir/certs            # Where the issued certs are kept
+crl_dir         = $dir/crl              # Where the issued crl are kept
+database        = $dir/index.txt        # database index file.
+#unique_subject = no                    # Set to 'no' to allow creation of
+                                        # several ctificates with same subject.
+new_certs_dir   = $dir/certs            # default place for new certs.
 
-certificate	= $dir/cacert.pem 	# The CA certificate
-serial		= $dir/serial 		# The current serial number
-crlnumber	= $dir/crlnumber	# the current crl number
-					# must be commented out to leave a V1 CRL
-crl		= $dir/crl.pem 		# The current CRL
-private_key	= $dir/private/cakey.pem# The private key
-RANDFILE	= $dir/private/.rand	# private random number file
+certificate = $dir/cacert.pem   # The CA certificate
+serial    = $dir/serial     # The current serial number
+crl   = $dir/crl.pem    # The current CRL
+private_key = $dir/private/cakey.pem  # The private key
+RANDFILE  = $dir/private/.rand  # private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions = usr_cert    # The extentions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
-name_opt 	= ca_default		# Subject Name options
-cert_opt 	= ca_default		# Certificate field options
+name_opt  = ca_default    # Subject Name options
+cert_opt  = ca_default    # Certificate field options
 
 # Extension copying option: use with caution.
 # copy_extensions = copy
 
 # Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
 # so this is commented out by default to leave a V1 CRL.
-# crlnumber must also be commented out to leave a V1 CRL.
-# crl_extensions	= crl_ext
+# crl_extensions  = crl_ext
 
-default_days	= 365			# how long to certify for
-default_crl_days= 30			# how long before next CRL
-default_md	= default		# use public key default MD
-preserve	= no			# keep passed DN ordering
+default_days  = 365     # how long to certify for
+default_crl_days= 30      # how long before next CRL
+default_md  = sha256      # which md to use.
+preserve  = no      # keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
-policy		= policy_match
+policy    = policy_anything
 
 # For the CA policy
 [ policy_match ]
-countryName		= match
-stateOrProvinceName	= match
-organizationName	= match
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName   = match
+stateOrProvinceName = match
+organizationName  = match
+organizationalUnitName  = optional
+commonName    = supplied
+emailAddress    = optional
 
 # For the 'anything' policy
 # At this point in time, you must list all acceptable 'object'
 # types.
 [ policy_anything ]
-countryName		= optional
-stateOrProvinceName	= optional
-localityName		= optional
-organizationName	= optional
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName   = optional
+stateOrProvinceName = optional
+localityName    = optional
+organizationName  = optional
+organizationalUnitName  = optional
+commonName    = supplied
+emailAddress    = optional
 
 ####################################################################
 [ req ]
-default_bits		= 2048
-default_md		= sha1
-default_keyfile 	= private/cakey.pem
-distinguished_name	= req_distinguished_name
-attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+default_bits    = 2048
+default_keyfile   = private/cakey.pem
+distinguished_name  = req_distinguished_name
+attributes    = req_attributes
+x509_extensions = v3_ca # The extentions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = secret
@@ -128,51 +120,54 @@ x509_extensions	= v3_ca	# The extentions to add to the self signed cert
 
 # This sets a mask for permitted string types. There are several options. 
 # default: PrintableString, T61String, BMPString.
-# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
-# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# pkix   : PrintableString, BMPString.
+# utf8only: only UTF8Strings.
 # nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
 # MASK:XXXX a literal mask value.
-# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
-string_mask = utf8only
+# WARNING: current versions of Netscape crash on BMPStrings or UTF8Strings
+# so use this option with caution!
+string_mask = nombstr
 
 # req_extensions = v3_req # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= XX
-countryName_min			= 2
-countryName_max			= 2
+countryName     = Country Name (2 letter code)
+countryName_default   = ZZ
+countryName_min     = 2
+countryName_max     = 2
 
-stateOrProvinceName		= State or Province Name (full name)
-#stateOrProvinceName_default	= Default Province
+#stateOrProvinceName    = State or Province Name (full name)
+#stateOrProvinceName_default  = Berkshire
 
-localityName			= Locality Name (eg, city)
-localityName_default	= Default City
+#localityName     = Locality Name (eg, city)
+#localityName_default   = Newbury
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Default Company Ltd
+0.organizationName    = Organization Name (eg, company)
+0.organizationName_default  = Fake Org
 
 # we can do this but it is not needed normally :-)
-#1.organizationName		= Second Organization Name (eg, company)
-#1.organizationName_default	= World Wide Web Pty Ltd
+#1.organizationName   = Second Organization Name (eg, company)
+#1.organizationName_default = World Wide Web Pty Ltd
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
+organizationalUnitName    = Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Hosts
 
-commonName			= Common Name (eg, your name or your server\'s hostname)
-commonName_max			= 64
+commonName      = Common Name (eg, your name or your server\'s hostname)
+commonName_max      = 64
+commonName_default    = Fake Org Fake CA - d59341ee
 
-emailAddress			= Email Address
-emailAddress_max		= 64
+#emailAddress     = Email Address
+#emailAddress_max   = 64
 
-# SET-ex3			= SET extension number 3
+# SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-challengePassword		= A challenge password
-challengePassword_min		= 4
-challengePassword_max		= 20
+#challengePassword    = A challenge password
+#challengePassword_min    = 4
+#challengePassword_max    = 20
+#challengePassword_default  = password
 
-unstructuredName		= An optional company name
+unstructuredName    = An optional company name
 
 [ usr_cert ]
 
@@ -187,7 +182,7 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-# nsCertType			= server
+# nsCertType      = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
@@ -202,15 +197,15 @@ basicConstraints=CA:FALSE
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+nsComment     = "Completely Fake Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer
+authorityKeyIdentifier=keyid,issuer:always
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
-# subjectAltName=email:copy
+subjectAltName=email:copy
 # An alternative to produce certificates that aren't
 # deprecated according to PKIX.
 # subjectAltName=email:move
@@ -218,22 +213,20 @@ authorityKeyIdentifier=keyid,issuer
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
 #nsCaPolicyUrl
 #nsSslServerName
 
-# This is required for TSA certificates.
-# extendedKeyUsage = critical,timeStamping
-
 [ v3_req ]
 
 # Extensions to add to a certificate request
 
 basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+#keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+keyUsage = keyEncipherment
 
 [ v3_ca ]
 
@@ -245,7 +238,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 subjectKeyIdentifier=hash
 
-authorityKeyIdentifier=keyid:always,issuer
+authorityKeyIdentifier=keyid:always,issuer:always
 
 # This is what PKIX recommends but some broken software chokes on critical
 # extensions.
@@ -278,10 +271,11 @@ basicConstraints = CA:true
 # Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
 
 # issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always
+authorityKeyIdentifier=keyid:always,issuer:always
 
-[ proxy_cert_ext ]
-# These extensions should be added when creating a proxy certificate
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
 
 # This goes against PKIX guidelines but some CAs do it and some software
 # requires this to avoid interpreting an end user certificate as a CA.
@@ -292,26 +286,27 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-# nsCertType			= server
+#nsCertType                     = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
 
 # For normal client use this is typical
-# nsCertType = client, email
+nsCertType = client, email
+# nsCertType = client
 
 # and for everything including object signing:
-# nsCertType = client, email, objsign
+#nsCertType = server, client, email, objsign
 
 # This is typical in keyUsage for a client certificate.
-# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+#nsComment                      = "Test Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer
+authorityKeyIdentifier=keyid,issuer:always
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
@@ -323,53 +318,23 @@ authorityKeyIdentifier=keyid,issuer
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl              = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
 #nsCaPolicyUrl
 #nsSslServerName
 
-# This really needs to be in place for it to be a proxy certificate.
-proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
 
-####################################################################
-[ tsa ]
-
-default_tsa = tsa_config1	# the default TSA section
-
-[ tsa_config1 ]
-
-# These are used by the TSA reply generation only.
-dir		= ./demoCA		# TSA root directory
-serial		= $dir/tsaserial	# The current serial number (mandatory)
-crypto_device	= builtin		# OpenSSL engine to use for signing
-signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
-					# (optional)
-certs		= $dir/cacert.pem	# Certificate chain to include in reply
-					# (optional)
-signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
-
-default_policy	= tsa_policy1		# Policy if request did not specify it
-					# (optional)
-other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
-digests		= md5, sha1		# Acceptable message digests (mandatory)
-accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
-clock_precision_digits  = 0	# number of digits after dot. (optional)
-ordering		= yes	# Is ordering defined for timestamps?
-				# (optional, default: no)
-tsa_name		= yes	# Must the TSA name be included in the reply?
-				# (optional, default: no)
-ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
-				# (optional, default: no)
 
 """
 
 class CA:
 
-    def __init__(self, cadir, subj):
+    def __init__(self, cadir, subj, force):
         self.cadir = self.normalize_directory_path(cadir)
         self.subj = subj
+        self.force = force
 
     def normalize_directory_path(self, path):
         if path.endswith(os.sep):
@@ -385,8 +350,18 @@ class CA:
                 return dict(success=False, msg=e)
         return dict(success=True)
 
+    def log(self, msg):
+        logifle = open('/tmp/tcri-cert.log', 'a')
+        logifle.write(msg)
+        logifle.write("\n")
+        logifle.write("\n")
+        logifle.close()
+
     def execute_command(self, cmd):
         call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+
+    def check_if_ca_exists(self):
+        return os.path.isfile(fname) 
 
     def validate_setup(self):
         certDirValid = self.create_dir_if_not_exist(self.cadir)
@@ -474,15 +449,13 @@ class CA:
             return dict(success=True, changed=False, changes=[], msg="CA directory '{0}' does not exist.".format(self.cadir))
 
 
-
-
-
 def main():
 
     BASE_MODULE_ARGS = dict(
         certdir = dict(default="/etc/certs"),
         subj = dict(default="/DC=com/DC=example/CN=CA/"),
-        state = dict(default="present", choices=["present", "absent"])
+        state = dict(default="present", choices=["present", "absent"]),
+        force = dict(default="false", choices=["true", "false"])
     )
 
     module = AnsibleModule(
@@ -490,7 +463,11 @@ def main():
         supports_check_mode=True
     )
 
-    ca = CA(module.params["certdir"], module.params["subj"])
+    ca = CA(module.params["certdir"], module.params["subj"], module.params["force"])
+
+    if not ca.force:
+       if ca.check_if_ca_exists():
+         module.exit_json(dict(changed=false, skip_reason="Conditional check failed", skipped=true));
 
     isValid = ca.validate_setup()
 

--- a/dist/certificate
+++ b/dist/certificate
@@ -4,19 +4,15 @@
 import os
 from subprocess import call
 
-#  echo "running openssl req"
-#  openssl req -new -nodes -keyout ../../keydist/$hname/$hname.pem -out working/"$hname"req.pem -days 360 -batch;
-#  echo "running openssl ca"
-#  openssl ca -passin file:cacertkey -batch -out ../../keydist/$hname/$hname.pub -infiles working/"$hname"req.pem
-
-#  cat ../../keydist/$hname/$hname.pub >> ../../keydist/$hname/$hname.pem
 
 KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
 TMPL_GEN_PK =   "openssl genrsa -out {0}.key.pem {1}"
 TMPL_GEN_REQ =  "openssl req -config {0}/openssl.cnf -new -key {1}.key.pem -out {1}.req.pem -outform PEM -subj \"{2}\" -nodes"
+
 TMPL_SIGN_REQ = "openssl ca -config {0}/openssl.cnf -in {1}/{2}.req.pem -out {1}/{2}.cert.pem.pub  -batch -extensions {3}"
-TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1}"
+
+TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -name {0} -chain -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1} -CApath {2}"
 TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile private/cakey.pem -cert cacert.pem"
 TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile private/cakey.pem -cert cacert.pem -out crl.pem"
 DEV_NULL = open('/dev/null', 'w')
@@ -30,11 +26,12 @@ OPENSSL_CNF = """
 
 # This definition stops the following lines choking if HOME isn't
 # defined.
-HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+HOME      = .
+RANDFILE    = $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
-#oid_file		= $ENV::HOME/.oid
+#oid_file   = $ENV::HOME/.oid
+
 
 [ ca ]
 default_ca = ca
@@ -51,7 +48,7 @@ default_crl_days = 7
 default_days = 365
 default_md = sha1
 
-policy = ca_policy
+policy = policy_match
 x509_extensions = certificate_extensions
 
 
@@ -60,56 +57,58 @@ output_password = test
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
-name_opt 	= ca_default		# Subject Name options
-cert_opt 	= ca_default		# Certificate field options
+name_opt  = ca_default    # Subject Name options
+cert_opt  = ca_default    # Certificate field options
 
 # Extension copying option: use with caution.
 # copy_extensions = copy
 
 # Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
 # so this is commented out by default to leave a V1 CRL.
-# crl_extensions	= crl_ext
+# crl_extensions  = crl_ext
 
-default_days	= 365			# how long to certify for
-default_crl_days= 30			# how long before next CRL
-default_md	= sha256			# which md to use.
-preserve	= no			# keep passed DN ordering
+default_days  = 365     # how long to certify for
+default_crl_days= 30      # how long before next CRL
+default_md  = sha256      # which md to use.
+preserve  = no      # keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
-#policy		= policy_anything
+policy    = policy_anything
 
-policy = ca_policy
+#policy = policy_match
 
-[ ca_policy ]
-commonName = supplied
-stateOrProvinceName = optional
-countryName = optional
-emailAddress = optional
-organizationName = optional
-organizationalUnitName = optional
+# For the CA policy
+[ policy_match ]
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
 
 # For the 'anything' policy
 # At this point in time, you must list all acceptable 'object'
 # types.
 [ policy_anything ]
-countryName		= optional
-stateOrProvinceName	= optional
-localityName		= optional
-organizationName	= optional
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
 
 [ certificate_extensions ]
 basicConstraints = CA:false
 
 ####################################################################
 [ req ]
-default_bits		= 2048
-default_keyfile 	= privkey.pem
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+dir = {0}
+default_bits    = 2048
+default_key = $dir/private/cakey.pem
+x509_extensions = v3_ca # The extentions to add to the self signed cert
 distinguished_name      = req_distinguished_name
 attributes              = req_attributes
 
@@ -119,7 +118,7 @@ attributes              = req_attributes
 
 # This sets a mask for permitted string types. There are several options. 
 # default: PrintableString, T61String, BMPString.
-# pkix	 : PrintableString, BMPString.
+# pkix   : PrintableString, BMPString.
 # utf8only: only UTF8Strings.
 # nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
 # MASK:XXXX a literal mask value.
@@ -130,43 +129,43 @@ string_mask = nombstr
 # req_extensions = v3_req # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= US
-countryName_min			= 2
-countryName_max			= 2
+countryName     = Country Name (2 letter code)
+countryName_default   = US
+countryName_min     = 2
+countryName_max     = 2
 
-#stateOrProvinceName		= State or Province Name (full name)
-#stateOrProvinceName_default	= Berkshire
+#stateOrProvinceName    = State or Province Name (full name)
+#stateOrProvinceName_default  = Berkshire
 
-#localityName			= Locality Name (eg, city)
-#localityName_default		= Newbury
+#localityName     = Locality Name (eg, city)
+#localityName_default   = Newbury
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Tactical Cloud Reference Implmentation
+0.organizationName    = Organization Name (eg, company)
+0.organizationName_default  = Tactical Cloud Reference Implmentation
 
 # we can do this but it is not needed normally :-)
-#1.organizationName		= Second Organization Name (eg, company)
-#1.organizationName_default	= ONR Test
+#1.organizationName   = Second Organization Name (eg, company)
+#1.organizationName_default = ONR Test
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-organizationalUnitName_default	= Hosts
+organizationalUnitName    = Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Hosts
 
-commonName			= Common Name (eg, your name or your server\'s hostname)
-commonName_max			= 64
-commonName_default		= {1}
+commonName      = Common Name (eg, your name or your server\'s hostname)
+commonName_max      = 64
+commonName_default    = {1}
 
-#emailAddress			= Email Address
-#emailAddress_max		= 64
+#emailAddress     = Email Address
+#emailAddress_max   = 64
 
-# SET-ex3			= SET extension number 3
+# SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-#challengePassword		= A challenge password
-#challengePassword_min		= 4
-#challengePassword_max		= 20
-#challengePassword_default	= password
+#challengePassword    = A challenge password
+#challengePassword_min    = 4
+#challengePassword_max    = 20
+#challengePassword_default  = password
 
-unstructuredName		= FakeCert
+unstructuredName    = FakeCert
 
 [ server_ca_extensions ]
 
@@ -181,7 +180,7 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-#nsCertType			= server
+#nsCertType     = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
@@ -197,7 +196,7 @@ nsCertType = server, client, email, objsign
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-#nsComment			= "Test Certificate"
+#nsComment      = "Test Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -216,7 +215,7 @@ subjectAltName = {2}
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
@@ -293,7 +292,6 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
-        self.log(cmd)
         call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):
@@ -309,11 +307,11 @@ class Certificate:
         self.execute_command(cmd)
 
     def generate_certificate_request(self):
-        cmd = TMPL_GEN_REQ.format(self.get_target_path(), self.get_target_path() + "/" + self.certname, self.subj)
+        cmd = TMPL_GEN_REQ.format(self.get_openssl_cnf(), self.get_target_path() + "/" + self.certname, self.subj)
         self.execute_command(cmd)
   
     def log(self, msg):
-        logifle = open('/private/tmp/ca.log', 'a')
+        logifle = open('/tmp/ca.log', 'a')
         logifle.write(msg)
         logifle.write("\n")
         logifle.write("\n")
@@ -321,8 +319,9 @@ class Certificate:
 
     def sign_certificate_request(self, curdir):
         os.chdir("..")
-        ext = "server_ca_extensions" if self.isServerCert else "client_ca_extensions"
-        cmd = TMPL_SIGN_REQ.format(self.get_target_path(), self.get_target_path(), self.certname, ext)
+        cmd = ""
+        ext = "server_ca_extensions -policy policy_anything " if self.isServerCert else "usr_cert -policy policy_anything"
+        cmd = TMPL_SIGN_REQ.format(self.get_openssl_cnf(), self.get_target_path(), self.certname, ext)
         self.execute_command(cmd)
         os.chdir(curdir)
 
@@ -338,9 +337,12 @@ class Certificate:
         passwordFile = self.get_target_path() + "/" +  self.certname + ".password"
         with open(passwordFile, "w") as f:
             f.write(self.p12password)
-        cmd = TMPL_PKCS12.format(self.certname, passwordFile)
+        cmd = TMPL_PKCS12.format(self.certname, passwordFile, self.cadir)
         self.execute_command(cmd)
         os.remove(passwordFile)
+
+    def get_openssl_cnf(self):
+        return self.cadir + "/server/" + self.certname  if self.isServerCert else self.cadir
 
     def get_target_path(self):
         return self.cadir + "/server/" + self.certname  if self.isServerCert else self.cadir + "/client"
@@ -382,7 +384,6 @@ class Certificate:
 
         target_path = self.get_target_path()
 
-        self.log("calling ensure with {0}".format(target_path))
         self.ensure_directory_exists(target_path)
 
         os.chdir(target_path)
@@ -393,34 +394,25 @@ class Certificate:
             changes.append("Created server cnf for {0}.".format(self.certname))
             changed = True
 
-        self.log("here {0}".format(os.path.exists(self.certname + ".key.pem")))
         if not os.path.exists(self.certname + ".key.pem"):
             self.generate_private_key()
             changes.append("Created private key for {0}.".format(self.certname))
             changed = True
 
-        self.log("here2")
-        self.log("here {0}".format(os.path.exists(self.certname + ".req.pem")))
         if not os.path.exists(self.certname + ".req.pem"):
             self.generate_certificate_request()
             changes.append("Created certificate request for {0}".format(self.certname))
             changed = True
 
-        self.log("here3")
-        self.log("here {0}".format(os.path.exists(self.certname + ".cert.pem.pub")))
         if not os.path.exists(self.certname + ".cert.pem.pub"):
             self.sign_certificate_request(target_path)
             changes.append("Signed certificate for {0}".format(self.certname))
             changed = True
 
-        self.log("here4")
-        self.log("here {0}".format(os.path.exists(self.certname + ".keycert.pem")))
         if not os.path.exists(self.certname + ".keycert.pem"):
             self.create_key_cert_PEM()
             changes.append("Created key-cert PEM file for {0}".format(self.certname))
 
-        self.log("here5")
-        self.log("here {0}".format(os.path.exists(self.certname + ".keycert.p12")))
         if not os.path.exists(self.certname + ".keycert.p12"):
             self.export_key_as_PKCS12()
             changes.append("Created PKCS12 version of the Private Key/Certificate Pair for {0}".format(self.certname))
@@ -487,6 +479,7 @@ class Certificate:
         os.chdir(CURDIR)
 
         return dict(success=True, changed=changed, changes=changes)
+
 
 
 

--- a/dist/certificate
+++ b/dist/certificate
@@ -1,6 +1,54 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+DOCUMENTATION = '''
+---
+module: certificate
+short_description: Manages server and client certificates.  
+description:
+    - Creates public, private certificates in PEM and PKCS12 formats
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  cadir:
+    description:
+      - The directory to store the certificate
+    required: true
+  certname:
+    description:
+      - The CN (common name) for the certificate
+    required: true
+  subj:
+    description:
+      - The full subject path for the certificate
+    required: true
+  p12password:
+    description:
+      - The password for the PKCS12 certificate
+    required: true
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  subjectAltNames:
+    description:
+      - Alternative names for the certificate.  Can be DNS, IP, etc.
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+- name: Create a Server Cert
+  certificate: cadir="/etc/certs" hostname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}"
+
+- name: Create a Client Cert
+  certificate: cadir="/etc/certs" hostname="client.example.com" subj="/DC=com/DC=example/CN=client/" p12password="{{some_env_var}}" certtype="client"
+
+- name: Remove a Server Cert
+  certificate: cadir="/etc/certs" hostname="server.example.com" subj="doesn't matter" p12password="blah!" state="absent"
+'''
+
 import os
 from subprocess import call
 
@@ -264,6 +312,7 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
+        self.log(cmd)
         call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):

--- a/dist/certificate
+++ b/dist/certificate
@@ -4,6 +4,8 @@
 import os
 from subprocess import call
 
+import time
+
 
 KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
@@ -13,8 +15,8 @@ TMPL_GEN_REQ =  "openssl req -config {0}/openssl.cnf -new -key {1}.key.pem -out 
 TMPL_SIGN_REQ = "openssl ca -config {0}/openssl.cnf -in {1}/{2}.req.pem -out {1}/{2}.cert.pem.pub  -batch -extensions {3}"
 
 TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -name {0} -chain -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1} -CApath {2}"
-TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile private/cakey.pem -cert cacert.pem"
-TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile private/cakey.pem -cert cacert.pem -out crl.pem"
+TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile {0}/private/cakey.pem -cert {0}/cacert.pem"
+TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile {0}/private/cakey.pem -cert {0}/cacert.pem -out crl.pem"
 DEV_NULL = open('/dev/null', 'w')
 
 
@@ -211,17 +213,6 @@ authorityKeyIdentifier=keyid,issuer:always
 
 subjectAltName = {2}
 
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
-
 [ v3_req ]
 
 # Extensions to add to a certificate request
@@ -247,25 +238,6 @@ authorityKeyIdentifier=keyid:always,issuer:always
 # So we do this instead.
 basicConstraints = CA:true
 
-# Key usage: this is typical for a CA certificate. However since it will
-# prevent it being used as an test self-signed certificate it is best
-# left out by default.
-# keyUsage = cRLSign, keyCertSign
-
-# Some might want this also
-# nsCertType = sslCA, emailCA
-
-# Include email address in subject alt name: another PKIX recommendation
-# subjectAltName=email:copy
-# Copy issuer details
-# issuerAltName=issuer:copy
-
-# DER hex encoding of an extension: beware experts only!
-# obj=DER:02:03
-# Where 'obj' is a standard or added object
-# You can even override a supported extension:
-# basicConstraints= critical, DER:30:03:01:01:FF
-
 [ crl_ext ]
 
 # CRL extensions.
@@ -278,7 +250,7 @@ authorityKeyIdentifier=keyid:always,issuer:always
 class Certificate:
 
     def __init__(self, cadir, certname, subj, p12password, isServerCert, subjectAltNames):
-        self.cadir = self.normalize_directory_path(cadir)
+        self.cadir = os.path.realpath(self.normalize_directory_path(cadir))
         self.certname = certname
         self.subj = subj
         self.p12password = p12password
@@ -292,7 +264,7 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
-        call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+        call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):
         with open(filename, "r") as f:
@@ -367,7 +339,7 @@ class Certificate:
         fileOpensslCnf = target_path + "/openssl" + ".cnf"
         if not os.path.exists(fileOpensslCnf):
             opensslCnf = open(fileOpensslCnf, "w")
-            alt_names = "DNS:" + self.certname
+            alt_names = self.subjectAltNames
             opensslCnf.write(OPENSSL_CNF.format(self.cadir, self.certname, alt_names))
             opensslCnf.close()
             changed = True        
@@ -377,10 +349,10 @@ class Certificate:
 
         CURDIR = os.getcwd()
 
+        os.chdir(self.cadir)
+
         changed = False
         changes = []
-
-        os.chdir(self.cadir)
 
         target_path = self.get_target_path()
 

--- a/dist/keytool
+++ b/dist/keytool
@@ -5,29 +5,31 @@
 from subprocess import call
 import os
 
-TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass:file {3}.storepass"
+TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass {3}"
+TMPL_GEN_SS = "keytool -importkeystore -noprompt -alias {0} -srckeystore {1} -destkeystore {2}  -srcstoretype PKCS12   -deststorepass {3} -destkeypass {3} -srcstorepass {4}"
+
 DEV_NULL = open('/dev/null', 'w')
 
 class Keytool:
 
 
-    def __init__(self, cadir, certname, store_password, hosts_to_trust, certtype):
+    def __init__(self, cadir, certname, store_password, hosts_to_trust, certtype, src_password):
 
         self.cadir = cadir
         self.certname = certname
         self.certtype = certtype
         self.store_password = store_password
+        self.src_password = src_password
         self.hosts_to_trust = hosts_to_trust
 
     def log(self, msg):
-        logifle = open('/private/tmp/keytoo.log', 'a')
+        logifle = open('/tmp/keytoo.log', 'a')
         logifle.write(msg)
         logifle.write("\n")
         logifle.write("\n")
         logifle.close()
 
     def execute_command(self, cmd):
-        self.log(cmd)
         call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def validate(self):
@@ -45,7 +47,7 @@ class Keytool:
 
     def get_truststore_path(self, certtype):
         if certtype == "keystore":
-          return "keystores" + os.sep + self.certname + ".keystore.jks"
+          return self.cadir + "/keystores" + os.sep + self.certname + ".keystore.jks"
         else:
           return "truststores" + os.sep + self.certname + ".trust.jks"
 
@@ -53,8 +55,14 @@ class Keytool:
         return self.certname + ".storepass"
 
     def resolve_certificate(self, host):
-        server = self.cadir + "/server/{0}/{0}.cert.pem.pub".format(host)
-        client = self.cadir + "/client/{0}.cert.pem.pub".format(host)
+        server = ""
+        client = ""
+        if self.certtype == "keystore":
+          server = self.cadir + "/server/{0}/{0}.keycert.p12".format(host)
+          client = self.cadir + "/client/{0}.keycert.p12".format(host)
+        else:
+          server = self.cadir + "/server/{0}/{0}.cert.pem.pub".format(host)
+          client = self.cadir + "/client/{0}.keycert.pem".format(host)
         if os.path.exists(server):
             return server
         elif os.path.exists(client):
@@ -73,8 +81,6 @@ class Keytool:
 
         os.chdir(self.cadir)
 
-        self.log("cadir " + self.cadir)
-
         if self.certtype == "truststore":
           self.ensure_directory_exists("truststores")
         else:
@@ -82,38 +88,32 @@ class Keytool:
 
         truststore_path = self.get_truststore_path(self.certtype)
         storepass_path = self.get_storepass_path()
-        self.log("truststore_path " + truststore_path)
-        self.log("storepass_pass " + self.store_password)
-        self.log("storepass_path " + storepass_path)
 
         if not os.path.exists(truststore_path):
 
-            self.log("inside create")
             # Write the password out to file.
             with open(storepass_path, "w") as storepass:
                 storepass.write(self.store_password)
 
-            self.log("store pass written")
-
             try:
-                self.log("The certytpe: " + self.certtype)
 
                 if self.certtype == "truststore":
-                  self.log("going in here when not supposed to")
-                  cmd = TMPL_GEN_TS.format("CA", "cacert.pem", truststore_path, self.certname)
+                  cmd = TMPL_GEN_TS.format("CA", self.cadir + "/cacert.pem", truststore_path, self.store_password)
                   self.execute_command(cmd)
                   changed = True
                   changes.append("Added the CA Certificate to the truststore.")
-
-                self.log("Made it here")
-                #self.log("host_to_trust " + self.host_to_trust)
 
                 for host in self.hosts_to_trust:
 
                     hostcert = self.resolve_certificate(host)
 
+                    cmd = ""
                     if not hostcert is None:
-                        cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.certname)
+                        if self.certtype == "keystore":
+                          cmd = TMPL_GEN_SS.format(host, hostcert, truststore_path, self.store_password, self.src_password)
+                        else:
+                          cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.store_password)
+
                         changes.append("Executing: '{0}'".format(cmd))
                         self.execute_command(cmd)
                         changed = True
@@ -162,15 +162,19 @@ class Keytool:
 
 
 
+
+
+
 def main():
 
     BASE_MODULE_ARGS = dict(
         cadir = dict(default="/etc/certs"),
         certname = dict(required=True),
         store_password = dict(required=True),
-        hosts_to_trust = dict(required=True, type="list"),
+        hosts_to_trust = dict(required=False, type="list"),
         state = dict(default="present", choices=["present", "absent"]),
-        certtype = dict(required=False, default="truststore", choices=["truststore","keystore"])
+        certtype = dict(required=False, default="truststore", choices=["truststore","keystore"]),
+        src_password = dict(required=False)
     )
 
     module = AnsibleModule(
@@ -184,6 +188,7 @@ def main():
         module.params["store_password"],
         module.params["hosts_to_trust"],
         module.params["certtype"],
+        module.params["src_password"],
     )
 
     isValid = keytool.validate()

--- a/dist/keytool
+++ b/dist/keytool
@@ -5,8 +5,8 @@
 from subprocess import call
 import os
 
-TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass {3}"
-TMPL_GEN_SS = "keytool -importkeystore -noprompt -alias {0} -srckeystore {1} -destkeystore {2}  -srcstoretype PKCS12   -deststorepass {3} -destkeypass {3} -srcstorepass {4}"
+TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass '{3}'"
+TMPL_GEN_KS = "keytool -importkeystore -noprompt -alias {0} -srckeystore {1} -destkeystore {2}  -srcstoretype PKCS12   -deststorepass '{3}' -destkeypass '{3}' -srcstorepass '{4}'"
 
 DEV_NULL = open('/dev/null', 'w')
 
@@ -15,7 +15,7 @@ class Keytool:
 
     def __init__(self, cadir, certname, store_password, hosts_to_trust, certtype, src_password):
 
-        self.cadir = cadir
+        self.cadir = os.path.realpath(cadir)
         self.certname = certname
         self.certtype = certtype
         self.store_password = store_password
@@ -30,13 +30,13 @@ class Keytool:
         logifle.close()
 
     def execute_command(self, cmd):
-        call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+        call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def validate(self):
 
         if not os.path.exists(self.cadir):
             return dict(success=False, msg="CA directory '{0}' does not exist.".format(self.cadir))
-        elif len(self.hosts_to_trust) == 0:
+        elif len(self.hosts_to_trust) == 0 and self.certtype == 'truststore':
             return dict(success=False, msg="No hosts specified for the truststore.")
         else:
             return dict(success=True)
@@ -98,10 +98,15 @@ class Keytool:
             try:
 
                 if self.certtype == "truststore":
-                  cmd = TMPL_GEN_TS.format("CA", self.cadir + "/cacert.pem", truststore_path, self.store_password)
+                  cmd = TMPL_GEN_TS.format("CA", self.cadir + "/cacert.pem", self.cadir + "/" + truststore_path, self.store_password)
                   self.execute_command(cmd)
                   changed = True
                   changes.append("Added the CA Certificate to the truststore.")
+
+                if self.certtype == "keystore":
+                    hostcert = self.resolve_certificate(self.certname)
+                    cmd = TMPL_GEN_KS.format(self.certname, hostcert, truststore_path, self.store_password, self.src_password)
+                    self.execute_command(cmd)
 
                 for host in self.hosts_to_trust:
 
@@ -109,10 +114,7 @@ class Keytool:
 
                     cmd = ""
                     if not hostcert is None:
-                        if self.certtype == "keystore":
-                          cmd = TMPL_GEN_SS.format(host, hostcert, truststore_path, self.store_password, self.src_password)
-                        else:
-                          cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.store_password)
+                        cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.store_password)
 
                         changes.append("Executing: '{0}'".format(cmd))
                         self.execute_command(cmd)
@@ -127,7 +129,6 @@ class Keytool:
                 errors.append(e.message)
 
             finally:
-
                 # Remove the password
                 os.remove(storepass_path)
 

--- a/dist/keytool
+++ b/dist/keytool
@@ -1,6 +1,56 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+DOCUMENTATION = '''
+---
+module: keytool
+short_description: Manages keystores and truststores for java
+description:
+    - Creates and Manages java keystores and truststores
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  cadir:
+    description:
+      - The directory to store the certificate
+    required: true
+  certname:
+    description:
+      - The CN (common name) for the certificate
+    required: true
+  store_password:
+    description:
+      - The password for the store
+    required: true
+  host_to_trust:
+    description:
+      - A list of hsots to add to the truststore
+    required: false
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  certtype:
+    description:
+      - The certificate type.  Values: keystore or truststore
+    required: false
+  src_password:
+    description:
+      - Source password for the PKCS12 certificate that is being imported
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+- name: Create a java server trustore and trust the server hosts
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com"
+
+  - name: Create a java server keystore 
+    keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit'  certtype="keystore" src_password='changeit'
+'''
+
+
 
 from subprocess import call
 import os
@@ -30,13 +80,14 @@ class Keytool:
         logifle.close()
 
     def execute_command(self, cmd):
+        self.log(cmd)
         call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def validate(self):
 
         if not os.path.exists(self.cadir):
             return dict(success=False, msg="CA directory '{0}' does not exist.".format(self.cadir))
-        elif len(self.hosts_to_trust) == 0 and self.certtype == 'truststore':
+        elif self.certtype == 'truststore' and len(self.hosts_to_trust) == 0:
             return dict(success=False, msg="No hosts specified for the truststore.")
         else:
             return dict(success=True)
@@ -107,6 +158,9 @@ class Keytool:
                     hostcert = self.resolve_certificate(self.certname)
                     cmd = TMPL_GEN_KS.format(self.certname, hostcert, truststore_path, self.store_password, self.src_password)
                     self.execute_command(cmd)
+                    os.chdir(CURDIR)
+
+                    return dict(success=success, changed=changed, changes=changes, path=truststore_path, errors=errors, msg=", ".join(errors))
 
                 for host in self.hosts_to_trust:
 
@@ -126,11 +180,13 @@ class Keytool:
 
             except Exception as e:
                 success = False
+                self.log(e)
                 errors.append(e.message)
 
             finally:
                 # Remove the password
-                os.remove(storepass_path)
+                if os.path.exists(storepass_path):
+                    os.remove(storepass_path)
 
         if success == False:
             os.remove(truststore_path)

--- a/source/build.py
+++ b/source/build.py
@@ -27,6 +27,5 @@ def replace_import(filename, ansibleModule, importStatement, libraryToInsert):
     destination.close()
 
 for file_config in FILES_TO_BUILD:
-    print "Building file {0}.".format(file_config["file"])
     delete_old_build_file(file_config["file"])
     replace_import(file_config["file"], file_config["module"], file_config["import"], file_config["library"])

--- a/source/ca.py
+++ b/source/ca.py
@@ -15,109 +15,101 @@ OPENSSL_CNF = """
 
 # This definition stops the following lines choking if HOME isn't
 # defined.
-HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+HOME      = .
+RANDFILE    = $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
-#oid_file		= $ENV::HOME/.oid
-oid_section		= new_oids
+#oid_file   = $ENV::HOME/.oid
+oid_section   = new_oids
+
 
 # To use this configuration file with the "-extfile" option of the
 # "openssl x509" utility, name here the section containing the
 # X.509v3 extensions to use:
-# extensions		= 
+# extensions    = 
 # (Alternatively, use a configuration file that has only
 # X.509v3 extensions in its main [= default] section.)
 
 [ new_oids ]
 
-# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# We can add new OIDs in here for use by 'ca' and 'req'.
 # Add a simple OID like this:
 # testoid1=1.2.3.4
 # Or use config file substitution like this:
 
-# Policies used by the TSA examples.
-tsa_policy1 = 1.2.3.4.1
-tsa_policy2 = 1.2.3.4.5.6
-tsa_policy3 = 1.2.3.4.5.7
-
 ####################################################################
 [ ca ]
-default_ca	= CA_default		# The default ca section
+default_ca  = CA_default    # The default ca section
 
 ####################################################################
 [ CA_default ]
 
-dir		= {0} 			# Where everything is kept
-certs		= $dir/certs		# Where the issued certs are kept
-crl_dir		= $dir/crl		# Where the issued crl are kept
-database	= $dir/index.txt	# database index file.
-#unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
-new_certs_dir	= $dir/newcerts		# default place for new certs.
+dir             = {0}                   # Where everything is kept
+certs           = $dir/certs            # Where the issued certs are kept
+crl_dir         = $dir/crl              # Where the issued crl are kept
+database        = $dir/index.txt        # database index file.
+#unique_subject = no                    # Set to 'no' to allow creation of
+                                        # several ctificates with same subject.
+new_certs_dir   = $dir/certs            # default place for new certs.
 
-certificate	= $dir/cacert.pem 	# The CA certificate
-serial		= $dir/serial 		# The current serial number
-crlnumber	= $dir/crlnumber	# the current crl number
-					# must be commented out to leave a V1 CRL
-crl		= $dir/crl.pem 		# The current CRL
-private_key	= $dir/private/cakey.pem# The private key
-RANDFILE	= $dir/private/.rand	# private random number file
+certificate = $dir/cacert.pem   # The CA certificate
+serial    = $dir/serial     # The current serial number
+crl   = $dir/crl.pem    # The current CRL
+private_key = $dir/private/cakey.pem  # The private key
+RANDFILE  = $dir/private/.rand  # private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions = usr_cert    # The extentions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
-name_opt 	= ca_default		# Subject Name options
-cert_opt 	= ca_default		# Certificate field options
+name_opt  = ca_default    # Subject Name options
+cert_opt  = ca_default    # Certificate field options
 
 # Extension copying option: use with caution.
 # copy_extensions = copy
 
 # Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
 # so this is commented out by default to leave a V1 CRL.
-# crlnumber must also be commented out to leave a V1 CRL.
-# crl_extensions	= crl_ext
+# crl_extensions  = crl_ext
 
-default_days	= 365			# how long to certify for
-default_crl_days= 30			# how long before next CRL
-default_md	= default		# use public key default MD
-preserve	= no			# keep passed DN ordering
+default_days  = 365     # how long to certify for
+default_crl_days= 30      # how long before next CRL
+default_md  = sha256      # which md to use.
+preserve  = no      # keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
-policy		= policy_match
+policy    = policy_anything
 
 # For the CA policy
 [ policy_match ]
-countryName		= match
-stateOrProvinceName	= match
-organizationName	= match
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName   = match
+stateOrProvinceName = match
+organizationName  = match
+organizationalUnitName  = optional
+commonName    = supplied
+emailAddress    = optional
 
 # For the 'anything' policy
 # At this point in time, you must list all acceptable 'object'
 # types.
 [ policy_anything ]
-countryName		= optional
-stateOrProvinceName	= optional
-localityName		= optional
-organizationName	= optional
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName   = optional
+stateOrProvinceName = optional
+localityName    = optional
+organizationName  = optional
+organizationalUnitName  = optional
+commonName    = supplied
+emailAddress    = optional
 
 ####################################################################
 [ req ]
-default_bits		= 2048
-default_md		= sha1
-default_keyfile 	= private/cakey.pem
-distinguished_name	= req_distinguished_name
-attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+default_bits    = 2048
+default_keyfile   = private/cakey.pem
+distinguished_name  = req_distinguished_name
+attributes    = req_attributes
+x509_extensions = v3_ca # The extentions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = secret
@@ -125,51 +117,54 @@ x509_extensions	= v3_ca	# The extentions to add to the self signed cert
 
 # This sets a mask for permitted string types. There are several options. 
 # default: PrintableString, T61String, BMPString.
-# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
-# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# pkix   : PrintableString, BMPString.
+# utf8only: only UTF8Strings.
 # nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
 # MASK:XXXX a literal mask value.
-# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
-string_mask = utf8only
+# WARNING: current versions of Netscape crash on BMPStrings or UTF8Strings
+# so use this option with caution!
+string_mask = nombstr
 
 # req_extensions = v3_req # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= XX
-countryName_min			= 2
-countryName_max			= 2
+countryName     = Country Name (2 letter code)
+countryName_default   = ZZ
+countryName_min     = 2
+countryName_max     = 2
 
-stateOrProvinceName		= State or Province Name (full name)
-#stateOrProvinceName_default	= Default Province
+#stateOrProvinceName    = State or Province Name (full name)
+#stateOrProvinceName_default  = Berkshire
 
-localityName			= Locality Name (eg, city)
-localityName_default	= Default City
+#localityName     = Locality Name (eg, city)
+#localityName_default   = Newbury
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Default Company Ltd
+0.organizationName    = Organization Name (eg, company)
+0.organizationName_default  = Fake Org
 
 # we can do this but it is not needed normally :-)
-#1.organizationName		= Second Organization Name (eg, company)
-#1.organizationName_default	= World Wide Web Pty Ltd
+#1.organizationName   = Second Organization Name (eg, company)
+#1.organizationName_default = World Wide Web Pty Ltd
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-#organizationalUnitName_default	=
+organizationalUnitName    = Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Hosts
 
-commonName			= Common Name (eg, your name or your server\'s hostname)
-commonName_max			= 64
+commonName      = Common Name (eg, your name or your server\'s hostname)
+commonName_max      = 64
+commonName_default    = Fake Org Fake CA - d59341ee
 
-emailAddress			= Email Address
-emailAddress_max		= 64
+#emailAddress     = Email Address
+#emailAddress_max   = 64
 
-# SET-ex3			= SET extension number 3
+# SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-challengePassword		= A challenge password
-challengePassword_min		= 4
-challengePassword_max		= 20
+#challengePassword    = A challenge password
+#challengePassword_min    = 4
+#challengePassword_max    = 20
+#challengePassword_default  = password
 
-unstructuredName		= An optional company name
+unstructuredName    = An optional company name
 
 [ usr_cert ]
 
@@ -184,7 +179,7 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-# nsCertType			= server
+# nsCertType      = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
@@ -199,15 +194,15 @@ basicConstraints=CA:FALSE
 # keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+nsComment     = "Completely Fake Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer
+authorityKeyIdentifier=keyid,issuer:always
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
-# subjectAltName=email:copy
+subjectAltName=email:copy
 # An alternative to produce certificates that aren't
 # deprecated according to PKIX.
 # subjectAltName=email:move
@@ -215,22 +210,20 @@ authorityKeyIdentifier=keyid,issuer
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
 #nsCaPolicyUrl
 #nsSslServerName
 
-# This is required for TSA certificates.
-# extendedKeyUsage = critical,timeStamping
-
 [ v3_req ]
 
 # Extensions to add to a certificate request
 
 basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+#keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+keyUsage = keyEncipherment
 
 [ v3_ca ]
 
@@ -242,7 +235,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 subjectKeyIdentifier=hash
 
-authorityKeyIdentifier=keyid:always,issuer
+authorityKeyIdentifier=keyid:always,issuer:always
 
 # This is what PKIX recommends but some broken software chokes on critical
 # extensions.
@@ -275,10 +268,11 @@ basicConstraints = CA:true
 # Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
 
 # issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always
+authorityKeyIdentifier=keyid:always,issuer:always
 
-[ proxy_cert_ext ]
-# These extensions should be added when creating a proxy certificate
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
 
 # This goes against PKIX guidelines but some CAs do it and some software
 # requires this to avoid interpreting an end user certificate as a CA.
@@ -289,26 +283,27 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-# nsCertType			= server
+#nsCertType                     = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
 
 # For normal client use this is typical
-# nsCertType = client, email
+nsCertType = client, email
+# nsCertType = client
 
 # and for everything including object signing:
-# nsCertType = client, email, objsign
+#nsCertType = server, client, email, objsign
 
 # This is typical in keyUsage for a client certificate.
-# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-nsComment			= "OpenSSL Generated Certificate"
+#nsComment                      = "Test Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid,issuer
+authorityKeyIdentifier=keyid,issuer:always
 
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
@@ -320,53 +315,23 @@ authorityKeyIdentifier=keyid,issuer
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl              = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
 #nsCaPolicyUrl
 #nsSslServerName
 
-# This really needs to be in place for it to be a proxy certificate.
-proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
 
-####################################################################
-[ tsa ]
-
-default_tsa = tsa_config1	# the default TSA section
-
-[ tsa_config1 ]
-
-# These are used by the TSA reply generation only.
-dir		= ./demoCA		# TSA root directory
-serial		= $dir/tsaserial	# The current serial number (mandatory)
-crypto_device	= builtin		# OpenSSL engine to use for signing
-signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
-					# (optional)
-certs		= $dir/cacert.pem	# Certificate chain to include in reply
-					# (optional)
-signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
-
-default_policy	= tsa_policy1		# Policy if request did not specify it
-					# (optional)
-other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
-digests		= md5, sha1		# Acceptable message digests (mandatory)
-accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
-clock_precision_digits  = 0	# number of digits after dot. (optional)
-ordering		= yes	# Is ordering defined for timestamps?
-				# (optional, default: no)
-tsa_name		= yes	# Must the TSA name be included in the reply?
-				# (optional, default: no)
-ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
-				# (optional, default: no)
 
 """
 
 class CA:
 
-    def __init__(self, cadir, subj):
+    def __init__(self, cadir, subj, force):
         self.cadir = self.normalize_directory_path(cadir)
         self.subj = subj
+        self.force = force
 
     def normalize_directory_path(self, path):
         if path.endswith(os.sep):
@@ -382,8 +347,18 @@ class CA:
                 return dict(success=False, msg=e)
         return dict(success=True)
 
+    def log(self, msg):
+        logifle = open('/tmp/tcri-cert.log', 'a')
+        logifle.write(msg)
+        logifle.write("\n")
+        logifle.write("\n")
+        logifle.close()
+
     def execute_command(self, cmd):
         call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+
+    def check_if_ca_exists(self):
+        return os.path.isfile(fname) 
 
     def validate_setup(self):
         certDirValid = self.create_dir_if_not_exist(self.cadir)
@@ -469,6 +444,3 @@ class CA:
             return dict(success=True, changed=True, changes=["Directory '{0}' removed".format(self.cadir)])
         else:
             return dict(success=True, changed=False, changes=[], msg="CA directory '{0}' does not exist.".format(self.cadir))
-
-
-

--- a/source/ca.py
+++ b/source/ca.py
@@ -5,6 +5,7 @@ KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
 TMPL_CA_CERT = "openssl req -x509 -config openssl.cnf -newkey rsa:{0} -days {1} -out cacert.pem -outform PEM -subj \"{2}\" -nodes"
 TMPL_CONVERT = "openssl x509 -in cacert.pem -out cacert.cer -outform DER"
+TMPL_CA_HASH = "c_rehash -n {0} "
 DEV_NULL = open('/dev/null', 'w')
 
 OPENSSL_CNF = """
@@ -153,17 +154,9 @@ commonName      = Common Name (eg, your name or your server\'s hostname)
 commonName_max      = 64
 commonName_default    = Fake Org Fake CA - d59341ee
 
-#emailAddress     = Email Address
-#emailAddress_max   = 64
-
 # SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-#challengePassword    = A challenge password
-#challengePassword_min    = 4
-#challengePassword_max    = 20
-#challengePassword_default  = password
-
 unstructuredName    = An optional company name
 
 [ usr_cert ]
@@ -175,24 +168,6 @@ unstructuredName    = An optional company name
 
 basicConstraints=CA:FALSE
 
-# Here are some examples of the usage of nsCertType. If it is omitted
-# the certificate can be used for anything *except* object signing.
-
-# This is OK for an SSL server.
-# nsCertType      = server
-
-# For an object signing certificate this would be used.
-# nsCertType = objsign
-
-# For normal client use this is typical
-# nsCertType = client, email
-
-# and for everything including object signing:
-# nsCertType = client, email, objsign
-
-# This is typical in keyUsage for a client certificate.
-# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-
 # This will be displayed in Netscape's comment listbox.
 nsComment     = "Completely Fake Certificate"
 
@@ -203,19 +178,6 @@ authorityKeyIdentifier=keyid,issuer:always
 # This stuff is for subjectAltName and issuerAltname.
 # Import the email address.
 subjectAltName=email:copy
-# An alternative to produce certificates that aren't
-# deprecated according to PKIX.
-# subjectAltName=email:move
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
 
 [ v3_req ]
 
@@ -243,25 +205,6 @@ authorityKeyIdentifier=keyid:always,issuer:always
 # So we do this instead.
 basicConstraints = CA:true
 
-# Key usage: this is typical for a CA certificate. However since it will
-# prevent it being used as an test self-signed certificate it is best
-# left out by default.
-# keyUsage = cRLSign, keyCertSign
-
-# Some might want this also
-# nsCertType = sslCA, emailCA
-
-# Include email address in subject alt name: another PKIX recommendation
-# subjectAltName=email:copy
-# Copy issuer details
-# issuerAltName=issuer:copy
-
-# DER hex encoding of an extension: beware experts only!
-# obj=DER:02:03
-# Where 'obj' is a standard or added object
-# You can even override a supported extension:
-# basicConstraints= critical, DER:30:03:01:01:FF
-
 [ crl_ext ]
 
 # CRL extensions.
@@ -279,57 +222,22 @@ authorityKeyIdentifier=keyid:always,issuer:always
 
 basicConstraints=CA:FALSE
 
-# Here are some examples of the usage of nsCertType. If it is omitted
-# the certificate can be used for anything *except* object signing.
-
-# This is OK for an SSL server.
-#nsCertType                     = server
-
-# For an object signing certificate this would be used.
-# nsCertType = objsign
-
 # For normal client use this is typical
 nsCertType = client, email
-# nsCertType = client
-
-# and for everything including object signing:
-#nsCertType = server, client, email, objsign
 
 # This is typical in keyUsage for a client certificate.
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-# This will be displayed in Netscape's comment listbox.
-#nsComment                      = "Test Certificate"
-
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid,issuer:always
-
-# This stuff is for subjectAltName and issuerAltname.
-# Import the email address.
-# subjectAltName=email:copy
-# An alternative to produce certificates that aren't
-# deprecated according to PKIX.
-# subjectAltName=email:move
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl              = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
-
-
 
 """
 
 class CA:
 
     def __init__(self, cadir, subj, force):
-        self.cadir = self.normalize_directory_path(cadir)
+        self.cadir = os.path.realpath(self.normalize_directory_path(cadir))
         self.subj = subj
         self.force = force
 
@@ -422,6 +330,10 @@ class CA:
         if not os.path.exists(fileCaCert):
             cmd = TMPL_CA_CERT.format(KEY_STRENGTH, DAYS_VALID, self.subj)
             self.execute_command(cmd)
+
+            cmd = TMPL_CA_HASH.format(self.cadir)
+            self.execute_command(cmd)
+
             changes.append("Created CA certificate.")
             changed = True
 

--- a/source/ca_module.py
+++ b/source/ca_module.py
@@ -8,7 +8,8 @@ def main():
     BASE_MODULE_ARGS = dict(
         certdir = dict(default="/etc/certs"),
         subj = dict(default="/DC=com/DC=example/CN=CA/"),
-        state = dict(default="present", choices=["present", "absent"])
+        state = dict(default="present", choices=["present", "absent"]),
+        force = dict(default="false", choices=["true", "false"])
     )
 
     module = AnsibleModule(
@@ -16,7 +17,11 @@ def main():
         supports_check_mode=True
     )
 
-    ca = CA(module.params["certdir"], module.params["subj"])
+    ca = CA(module.params["certdir"], module.params["subj"], module.params["force"])
+
+    if not ca.force:
+       if ca.check_if_ca_exists():
+         module.exit_json(dict(changed=false, skip_reason="Conditional check failed", skipped=true));
 
     isValid = ca.validate_setup()
 

--- a/source/ca_module.py
+++ b/source/ca_module.py
@@ -1,6 +1,44 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+
+DOCUMENTATION = '''
+---
+module: ca
+short_description: Manages CA certificates
+description:
+    - Create, update, and delete for a CA
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  certdir:
+    description:
+      - The directory to store the certificate
+    required: true
+  subj:
+    description:
+      - The CA subject
+    required: true
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  force:
+    description:
+      - This will overwrite the CA
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+
+- name: Setup a CA
+  ca: certdir="/etc/certs" subj="/DC=com/DC=example/CN=CA/"
+- name: Remove a CA
+  ca: certdir="/etc/certs" subj="/CN=whatever/" state="absent"
+'''
+
 from ca import CA
 
 def main():

--- a/source/certificate.py
+++ b/source/certificate.py
@@ -290,7 +290,6 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
-        self.log(cmd)
         call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):
@@ -379,7 +378,6 @@ class Certificate:
 
         target_path = self.get_target_path()
 
-        self.log("calling ensure with {0}".format(target_path))
         self.ensure_directory_exists(target_path)
 
         os.chdir(target_path)
@@ -390,34 +388,25 @@ class Certificate:
             changes.append("Created server cnf for {0}.".format(self.certname))
             changed = True
 
-        self.log("here {0}".format(os.path.exists(self.certname + ".key.pem")))
         if not os.path.exists(self.certname + ".key.pem"):
             self.generate_private_key()
             changes.append("Created private key for {0}.".format(self.certname))
             changed = True
 
-        self.log("here2")
-        self.log("here {0}".format(os.path.exists(self.certname + ".req.pem")))
         if not os.path.exists(self.certname + ".req.pem"):
             self.generate_certificate_request()
             changes.append("Created certificate request for {0}".format(self.certname))
             changed = True
 
-        self.log("here3")
-        self.log("here {0}".format(os.path.exists(self.certname + ".cert.pem.pub")))
         if not os.path.exists(self.certname + ".cert.pem.pub"):
             self.sign_certificate_request(target_path)
             changes.append("Signed certificate for {0}".format(self.certname))
             changed = True
 
-        self.log("here4")
-        self.log("here {0}".format(os.path.exists(self.certname + ".keycert.pem")))
         if not os.path.exists(self.certname + ".keycert.pem"):
             self.create_key_cert_PEM()
             changes.append("Created key-cert PEM file for {0}".format(self.certname))
 
-        self.log("here5")
-        self.log("here {0}".format(os.path.exists(self.certname + ".keycert.p12")))
         if not os.path.exists(self.certname + ".keycert.p12"):
             self.export_key_as_PKCS12()
             changes.append("Created PKCS12 version of the Private Key/Certificate Pair for {0}".format(self.certname))

--- a/source/certificate.py
+++ b/source/certificate.py
@@ -1,19 +1,15 @@
 import os
 from subprocess import call
 
-#  echo "running openssl req"
-#  openssl req -new -nodes -keyout ../../keydist/$hname/$hname.pem -out working/"$hname"req.pem -days 360 -batch;
-#  echo "running openssl ca"
-#  openssl ca -passin file:cacertkey -batch -out ../../keydist/$hname/$hname.pub -infiles working/"$hname"req.pem
-
-#  cat ../../keydist/$hname/$hname.pub >> ../../keydist/$hname/$hname.pem
 
 KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
 TMPL_GEN_PK =   "openssl genrsa -out {0}.key.pem {1}"
 TMPL_GEN_REQ =  "openssl req -config {0}/openssl.cnf -new -key {1}.key.pem -out {1}.req.pem -outform PEM -subj \"{2}\" -nodes"
+
 TMPL_SIGN_REQ = "openssl ca -config {0}/openssl.cnf -in {1}/{2}.req.pem -out {1}/{2}.cert.pem.pub  -batch -extensions {3}"
-TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1}"
+
+TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -name {0} -chain -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1} -CApath {2}"
 TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile private/cakey.pem -cert cacert.pem"
 TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile private/cakey.pem -cert cacert.pem -out crl.pem"
 DEV_NULL = open('/dev/null', 'w')
@@ -27,11 +23,12 @@ OPENSSL_CNF = """
 
 # This definition stops the following lines choking if HOME isn't
 # defined.
-HOME			= .
-RANDFILE		= $ENV::HOME/.rnd
+HOME      = .
+RANDFILE    = $ENV::HOME/.rnd
 
 # Extra OBJECT IDENTIFIER info:
-#oid_file		= $ENV::HOME/.oid
+#oid_file   = $ENV::HOME/.oid
+
 
 [ ca ]
 default_ca = ca
@@ -48,7 +45,7 @@ default_crl_days = 7
 default_days = 365
 default_md = sha1
 
-policy = ca_policy
+policy = policy_match
 x509_extensions = certificate_extensions
 
 
@@ -57,56 +54,58 @@ output_password = test
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
-name_opt 	= ca_default		# Subject Name options
-cert_opt 	= ca_default		# Certificate field options
+name_opt  = ca_default    # Subject Name options
+cert_opt  = ca_default    # Certificate field options
 
 # Extension copying option: use with caution.
 # copy_extensions = copy
 
 # Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
 # so this is commented out by default to leave a V1 CRL.
-# crl_extensions	= crl_ext
+# crl_extensions  = crl_ext
 
-default_days	= 365			# how long to certify for
-default_crl_days= 30			# how long before next CRL
-default_md	= sha256			# which md to use.
-preserve	= no			# keep passed DN ordering
+default_days  = 365     # how long to certify for
+default_crl_days= 30      # how long before next CRL
+default_md  = sha256      # which md to use.
+preserve  = no      # keep passed DN ordering
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
-#policy		= policy_anything
+policy    = policy_anything
 
-policy = ca_policy
+#policy = policy_match
 
-[ ca_policy ]
-commonName = supplied
-stateOrProvinceName = optional
-countryName = optional
-emailAddress = optional
-organizationName = optional
-organizationalUnitName = optional
+# For the CA policy
+[ policy_match ]
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
 
 # For the 'anything' policy
 # At this point in time, you must list all acceptable 'object'
 # types.
 [ policy_anything ]
-countryName		= optional
-stateOrProvinceName	= optional
-localityName		= optional
-organizationName	= optional
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
 
 [ certificate_extensions ]
 basicConstraints = CA:false
 
 ####################################################################
 [ req ]
-default_bits		= 2048
-default_keyfile 	= privkey.pem
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+dir = {0}
+default_bits    = 2048
+default_key = $dir/private/cakey.pem
+x509_extensions = v3_ca # The extentions to add to the self signed cert
 distinguished_name      = req_distinguished_name
 attributes              = req_attributes
 
@@ -116,7 +115,7 @@ attributes              = req_attributes
 
 # This sets a mask for permitted string types. There are several options. 
 # default: PrintableString, T61String, BMPString.
-# pkix	 : PrintableString, BMPString.
+# pkix   : PrintableString, BMPString.
 # utf8only: only UTF8Strings.
 # nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
 # MASK:XXXX a literal mask value.
@@ -127,43 +126,43 @@ string_mask = nombstr
 # req_extensions = v3_req # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= US
-countryName_min			= 2
-countryName_max			= 2
+countryName     = Country Name (2 letter code)
+countryName_default   = US
+countryName_min     = 2
+countryName_max     = 2
 
-#stateOrProvinceName		= State or Province Name (full name)
-#stateOrProvinceName_default	= Berkshire
+#stateOrProvinceName    = State or Province Name (full name)
+#stateOrProvinceName_default  = Berkshire
 
-#localityName			= Locality Name (eg, city)
-#localityName_default		= Newbury
+#localityName     = Locality Name (eg, city)
+#localityName_default   = Newbury
 
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= Tactical Cloud Reference Implmentation
+0.organizationName    = Organization Name (eg, company)
+0.organizationName_default  = Tactical Cloud Reference Implmentation
 
 # we can do this but it is not needed normally :-)
-#1.organizationName		= Second Organization Name (eg, company)
-#1.organizationName_default	= ONR Test
+#1.organizationName   = Second Organization Name (eg, company)
+#1.organizationName_default = ONR Test
 
-organizationalUnitName		= Organizational Unit Name (eg, section)
-organizationalUnitName_default	= Hosts
+organizationalUnitName    = Organizational Unit Name (eg, section)
+organizationalUnitName_default  = Hosts
 
-commonName			= Common Name (eg, your name or your server\'s hostname)
-commonName_max			= 64
-commonName_default		= {1}
+commonName      = Common Name (eg, your name or your server\'s hostname)
+commonName_max      = 64
+commonName_default    = {1}
 
-#emailAddress			= Email Address
-#emailAddress_max		= 64
+#emailAddress     = Email Address
+#emailAddress_max   = 64
 
-# SET-ex3			= SET extension number 3
+# SET-ex3     = SET extension number 3
 
 [ req_attributes ]
-#challengePassword		= A challenge password
-#challengePassword_min		= 4
-#challengePassword_max		= 20
-#challengePassword_default	= password
+#challengePassword    = A challenge password
+#challengePassword_min    = 4
+#challengePassword_max    = 20
+#challengePassword_default  = password
 
-unstructuredName		= FakeCert
+unstructuredName    = FakeCert
 
 [ server_ca_extensions ]
 
@@ -178,7 +177,7 @@ basicConstraints=CA:FALSE
 # the certificate can be used for anything *except* object signing.
 
 # This is OK for an SSL server.
-#nsCertType			= server
+#nsCertType     = server
 
 # For an object signing certificate this would be used.
 # nsCertType = objsign
@@ -194,7 +193,7 @@ nsCertType = server, client, email, objsign
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 # This will be displayed in Netscape's comment listbox.
-#nsComment			= "Test Certificate"
+#nsComment      = "Test Certificate"
 
 # PKIX recommendations harmless if included in all certificates.
 subjectKeyIdentifier=hash
@@ -213,7 +212,7 @@ subjectAltName = {2}
 # Copy subject details
 # issuerAltName=issuer:copy
 
-#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
 #nsBaseUrl
 #nsRevocationUrl
 #nsRenewalUrl
@@ -305,11 +304,11 @@ class Certificate:
         self.execute_command(cmd)
 
     def generate_certificate_request(self):
-        cmd = TMPL_GEN_REQ.format(self.get_target_path(), self.get_target_path() + "/" + self.certname, self.subj)
+        cmd = TMPL_GEN_REQ.format(self.get_openssl_cnf(), self.get_target_path() + "/" + self.certname, self.subj)
         self.execute_command(cmd)
   
     def log(self, msg):
-        logifle = open('/private/tmp/ca.log', 'a')
+        logifle = open('/tmp/ca.log', 'a')
         logifle.write(msg)
         logifle.write("\n")
         logifle.write("\n")
@@ -317,8 +316,9 @@ class Certificate:
 
     def sign_certificate_request(self, curdir):
         os.chdir("..")
-        ext = "server_ca_extensions" if self.isServerCert else "client_ca_extensions"
-        cmd = TMPL_SIGN_REQ.format(self.get_target_path(), self.get_target_path(), self.certname, ext)
+        cmd = ""
+        ext = "server_ca_extensions -policy policy_anything " if self.isServerCert else "usr_cert -policy policy_anything"
+        cmd = TMPL_SIGN_REQ.format(self.get_openssl_cnf(), self.get_target_path(), self.certname, ext)
         self.execute_command(cmd)
         os.chdir(curdir)
 
@@ -334,9 +334,12 @@ class Certificate:
         passwordFile = self.get_target_path() + "/" +  self.certname + ".password"
         with open(passwordFile, "w") as f:
             f.write(self.p12password)
-        cmd = TMPL_PKCS12.format(self.certname, passwordFile)
+        cmd = TMPL_PKCS12.format(self.certname, passwordFile, self.cadir)
         self.execute_command(cmd)
         os.remove(passwordFile)
+
+    def get_openssl_cnf(self):
+        return self.cadir + "/server/" + self.certname  if self.isServerCert else self.cadir
 
     def get_target_path(self):
         return self.cadir + "/server/" + self.certname  if self.isServerCert else self.cadir + "/client"
@@ -473,5 +476,6 @@ class Certificate:
         os.chdir(CURDIR)
 
         return dict(success=True, changed=changed, changes=changes)
+
 
 

--- a/source/certificate.py
+++ b/source/certificate.py
@@ -1,6 +1,8 @@
 import os
 from subprocess import call
 
+import time
+
 
 KEY_STRENGTH = 2048
 DAYS_VALID  = 3653 # ~10 years
@@ -10,8 +12,8 @@ TMPL_GEN_REQ =  "openssl req -config {0}/openssl.cnf -new -key {1}.key.pem -out 
 TMPL_SIGN_REQ = "openssl ca -config {0}/openssl.cnf -in {1}/{2}.req.pem -out {1}/{2}.cert.pem.pub  -batch -extensions {3}"
 
 TMPL_PKCS12 =   "openssl pkcs12 -export -out {0}.keycert.p12 -name {0} -chain -in {0}.cert.pem.pub -inkey {0}.key.pem -passout file:{1} -CApath {2}"
-TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile private/cakey.pem -cert cacert.pem"
-TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile private/cakey.pem -cert cacert.pem -out crl.pem"
+TMPL_REVOKE = "openssl ca -config {0}/openssl.cnf -revoke {1} -keyfile {0}/private/cakey.pem -cert {0}/cacert.pem"
+TMPL_GEN_CRL = "openssl ca -config {0}/openssl.cnf -gencrl -keyfile {0}/private/cakey.pem -cert {0}/cacert.pem -out crl.pem"
 DEV_NULL = open('/dev/null', 'w')
 
 
@@ -208,17 +210,6 @@ authorityKeyIdentifier=keyid,issuer:always
 
 subjectAltName = {2}
 
-
-# Copy subject details
-# issuerAltName=issuer:copy
-
-#nsCaRevocationUrl    = http://www.domain.dom/ca-crl.pem
-#nsBaseUrl
-#nsRevocationUrl
-#nsRenewalUrl
-#nsCaPolicyUrl
-#nsSslServerName
-
 [ v3_req ]
 
 # Extensions to add to a certificate request
@@ -244,25 +235,6 @@ authorityKeyIdentifier=keyid:always,issuer:always
 # So we do this instead.
 basicConstraints = CA:true
 
-# Key usage: this is typical for a CA certificate. However since it will
-# prevent it being used as an test self-signed certificate it is best
-# left out by default.
-# keyUsage = cRLSign, keyCertSign
-
-# Some might want this also
-# nsCertType = sslCA, emailCA
-
-# Include email address in subject alt name: another PKIX recommendation
-# subjectAltName=email:copy
-# Copy issuer details
-# issuerAltName=issuer:copy
-
-# DER hex encoding of an extension: beware experts only!
-# obj=DER:02:03
-# Where 'obj' is a standard or added object
-# You can even override a supported extension:
-# basicConstraints= critical, DER:30:03:01:01:FF
-
 [ crl_ext ]
 
 # CRL extensions.
@@ -275,7 +247,7 @@ authorityKeyIdentifier=keyid:always,issuer:always
 class Certificate:
 
     def __init__(self, cadir, certname, subj, p12password, isServerCert, subjectAltNames):
-        self.cadir = self.normalize_directory_path(cadir)
+        self.cadir = os.path.realpath(self.normalize_directory_path(cadir))
         self.certname = certname
         self.subj = subj
         self.p12password = p12password
@@ -289,7 +261,7 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
-        call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+        call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):
         with open(filename, "r") as f:
@@ -364,7 +336,7 @@ class Certificate:
         fileOpensslCnf = target_path + "/openssl" + ".cnf"
         if not os.path.exists(fileOpensslCnf):
             opensslCnf = open(fileOpensslCnf, "w")
-            alt_names = "DNS:" + self.certname
+            alt_names = self.subjectAltNames
             opensslCnf.write(OPENSSL_CNF.format(self.cadir, self.certname, alt_names))
             opensslCnf.close()
             changed = True        
@@ -374,10 +346,10 @@ class Certificate:
 
         CURDIR = os.getcwd()
 
+        os.chdir(self.cadir)
+
         changed = False
         changes = []
-
-        os.chdir(self.cadir)
 
         target_path = self.get_target_path()
 

--- a/source/certificate.py
+++ b/source/certificate.py
@@ -261,7 +261,7 @@ class Certificate:
             return path
 
     def execute_command(self, cmd):
-        call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
+        call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def read_file(self, filename):
         with open(filename, "r") as f:

--- a/source/certificate_module.py
+++ b/source/certificate_module.py
@@ -1,6 +1,54 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+DOCUMENTATION = '''
+---
+module: certificate
+short_description: Manages server and client certificates.  
+description:
+    - Creates public, private certificates in PEM and PKCS12 formats
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  certdir:
+    description:
+      - The directory to store the certificate
+    required: true
+  certname:
+    description:
+      - The CN (common name) for the certificate
+    required: true
+  subj:
+    description:
+      - The full subject path for the certificate
+    required: true
+  p12password:
+    description:
+      - The password for the PKCS12 certificate
+    required: true
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  subjectAltNames:
+    description:
+      - Alternative names for the certificate.  Can be DNS, IP, etc.
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+- name: Create a Server Cert
+  certificate: cadir="/etc/certs" hostname="server.example.com" subj="/DC=com/DC=example/CN=server/" p12password="{{some_env_var}}"
+
+- name: Create a Client Cert
+  certificate: cadir="/etc/certs" hostname="client.example.com" subj="/DC=com/DC=example/CN=client/" p12password="{{some_env_var}}" certtype="client"
+
+- name: Remove a Server Cert
+  certificate: cadir="/etc/certs" hostname="server.example.com" subj="doesn't matter" p12password="blah!" state="absent"
+'''
+
 from certificate import Certificate
 
 def main():

--- a/source/certificate_module.py
+++ b/source/certificate_module.py
@@ -11,7 +11,7 @@ author:
     - "Richard Clayton (@rclayton-the-terrible)"
     - "James Whetsell (@zer0glitch)"
 options:
-  certdir:
+  cadir:
     description:
       - The directory to store the certificate
     required: true

--- a/source/keytool.py
+++ b/source/keytool.py
@@ -2,8 +2,8 @@
 from subprocess import call
 import os
 
-TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass {3}"
-TMPL_GEN_SS = "keytool -importkeystore -noprompt -alias {0} -srckeystore {1} -destkeystore {2}  -srcstoretype PKCS12   -deststorepass {3} -destkeypass {3} -srcstorepass {4}"
+TMPL_GEN_TS = "keytool -import -noprompt -alias {0} -file {1} -keystore {2} -storepass '{3}'"
+TMPL_GEN_KS = "keytool -importkeystore -noprompt -alias {0} -srckeystore {1} -destkeystore {2}  -srcstoretype PKCS12   -deststorepass '{3}' -destkeypass '{3}' -srcstorepass '{4}'"
 
 DEV_NULL = open('/dev/null', 'w')
 
@@ -12,7 +12,7 @@ class Keytool:
 
     def __init__(self, cadir, certname, store_password, hosts_to_trust, certtype, src_password):
 
-        self.cadir = cadir
+        self.cadir = os.path.realpath(cadir)
         self.certname = certname
         self.certtype = certtype
         self.store_password = store_password
@@ -27,13 +27,13 @@ class Keytool:
         logifle.close()
 
     def execute_command(self, cmd):
-        call(cmd, shell=True, stdout=DEV_NULL, stderr=DEV_NULL)
+        call(cmd, shell=True) #, stdout=DEV_NULL, stderr=DEV_NULL)
 
     def validate(self):
 
         if not os.path.exists(self.cadir):
             return dict(success=False, msg="CA directory '{0}' does not exist.".format(self.cadir))
-        elif len(self.hosts_to_trust) == 0:
+        elif len(self.hosts_to_trust) == 0 and self.certtype == 'truststore':
             return dict(success=False, msg="No hosts specified for the truststore.")
         else:
             return dict(success=True)
@@ -95,10 +95,15 @@ class Keytool:
             try:
 
                 if self.certtype == "truststore":
-                  cmd = TMPL_GEN_TS.format("CA", self.cadir + "/cacert.pem", truststore_path, self.store_password)
+                  cmd = TMPL_GEN_TS.format("CA", self.cadir + "/cacert.pem", self.cadir + "/" + truststore_path, self.store_password)
                   self.execute_command(cmd)
                   changed = True
                   changes.append("Added the CA Certificate to the truststore.")
+
+                if self.certtype == "keystore":
+                    hostcert = self.resolve_certificate(self.certname)
+                    cmd = TMPL_GEN_KS.format(self.certname, hostcert, truststore_path, self.store_password, self.src_password)
+                    self.execute_command(cmd)
 
                 for host in self.hosts_to_trust:
 
@@ -106,10 +111,7 @@ class Keytool:
 
                     cmd = ""
                     if not hostcert is None:
-                        if self.certtype == "keystore":
-                          cmd = TMPL_GEN_SS.format(host, hostcert, truststore_path, self.store_password, self.src_password)
-                        else:
-                          cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.store_password)
+                        cmd = TMPL_GEN_TS.format(host, hostcert, truststore_path, self.store_password)
 
                         changes.append("Executing: '{0}'".format(cmd))
                         self.execute_command(cmd)
@@ -124,7 +126,6 @@ class Keytool:
                 errors.append(e.message)
 
             finally:
-
                 # Remove the password
                 os.remove(storepass_path)
 

--- a/source/keytool_module.py
+++ b/source/keytool_module.py
@@ -1,6 +1,56 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+DOCUMENTATION = '''
+---
+module: keytool
+short_description: Manages keystores and truststores for java
+description:
+    - Creates and Manages java keystores and truststores
+author:
+    - "Richard Clayton (@rclayton-the-terrible)"
+    - "James Whetsell (@zer0glitch)"
+options:
+  cadir:
+    description:
+      - The directory to store the certificate
+    required: true
+  certname:
+    description:
+      - The CN (common name) for the certificate
+    required: true
+  store_password:
+    description:
+      - The password for the store
+    required: true
+  host_to_trust:
+    description:
+      - A list of hsots to add to the truststore
+    required: false
+  state:
+    description:
+      - To create or remove the CA. Present or absent: default is present.
+    required: false
+  certtype:
+    description:
+      - The certificate type.  Values: keystore or truststore
+    required: false
+  src_password:
+    description:
+      - Source password for the PKCS12 certificate that is being imported
+    required: false
+requirements: [ openssl ]
+'''
+
+EXAMPLES = '''
+- name: Create a java server trustore and trust the server hosts
+  keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit' hosts_to_trust="host1.example.com"
+
+  - name: Create a java server keystore 
+    keytool: cadir="/etc/certs" certname="host1.example.com" store_password='changeit'  certtype="keystore" src_password='changeit'
+'''
+
+
 from keytool import Keytool
 
 def main():

--- a/source/keytool_module.py
+++ b/source/keytool_module.py
@@ -9,7 +9,7 @@ def main():
         cadir = dict(default="/etc/certs"),
         certname = dict(required=True),
         store_password = dict(required=True),
-        hosts_to_trust = dict(required=True, type="list"),
+        hosts_to_trust = dict(required=False, type="list"),
         state = dict(default="present", choices=["present", "absent"]),
         certtype = dict(required=False, default="truststore", choices=["truststore","keystore"]),
         src_password = dict(required=False)

--- a/source/keytool_module.py
+++ b/source/keytool_module.py
@@ -11,7 +11,8 @@ def main():
         store_password = dict(required=True),
         hosts_to_trust = dict(required=True, type="list"),
         state = dict(default="present", choices=["present", "absent"]),
-        certtype = dict(required=False, default="truststore", choices=["truststore","keystore"])
+        certtype = dict(required=False, default="truststore", choices=["truststore","keystore"]),
+        src_password = dict(required=False)
     )
 
     module = AnsibleModule(
@@ -25,6 +26,7 @@ def main():
         module.params["store_password"],
         module.params["hosts_to_trust"],
         module.params["certtype"],
+        module.params["src_password"],
     )
 
     isValid = keytool.validate()

--- a/source/test.py
+++ b/source/test.py
@@ -8,7 +8,7 @@ line = "----------------------------------------------"
 
 cadir = "./testca"
 
-ca = CA(cadir, "/CN=Test CA/")
+ca = CA(cadir, "/CN=Test CA/", True)
 
 ca.validate_setup()
 
@@ -18,18 +18,18 @@ print "CA present"
 print line
 print r1
 
-def createCert(certname, subj, password, isServerCert):
+def createCert(certname, subj, password, isServerCert, subjAltName):
     print line
     print "Creating certificate for: {}".format(certname)
-    cert = Certificate(cadir, certname, subj, password, isServerCert)
+    cert = Certificate(cadir, certname, subj, password, isServerCert, subjAltName)
     print cert.create_certificate()
     return cert
 
 
-createCert("test.openampere.com", "/CN=Test/", "abc123!@#$", True)
-c1 = createCert("client.openampere.com", "/CN=Client/", "asdfaer13", False)
-createCert("client2.openampere.com", "/DC=com/DC=openampere/DC=test/CN=Client2", "asdf", False)
-s2 = createCert("test2.openampere.com", "/CN=Test 2", "asdf987", True)
+createCert("test.openampere.com", "/CN=Test/", "abc123!@#$", True, "DNS.1=client,DNS.2=test.openamepere.com,IP.1=192.168.1.2")
+c1 = createCert("client.openampere.com", "/CN=Client/", "asdfaer13", False, "")
+createCert("client2.openampere.com", "/DC=com/DC=openampere/DC=test/CN=Client2", "asdf", False, "")
+s2 = createCert("test2.openampere.com", "/CN=Test 2", "asdf987", True, "DNS.1=client,DNS.2=test.openamepere.com,IP.1=192.168.1.2")
 
 print line
 print "Removing cert for client.openampere.com"

--- a/source/test.py
+++ b/source/test.py
@@ -26,22 +26,31 @@ def createCert(certname, subj, password, isServerCert, subjAltName):
     return cert
 
 
-createCert("test.openampere.com", "/CN=Test/", "abc123!@#$", True, "DNS.1=client,DNS.2=test.openamepere.com,IP.1=192.168.1.2")
-c1 = createCert("client.openampere.com", "/CN=Client/", "asdfaer13", False, "")
-createCert("client2.openampere.com", "/DC=com/DC=openampere/DC=test/CN=Client2", "asdf", False, "")
-s2 = createCert("test2.openampere.com", "/CN=Test 2", "asdf987", True, "DNS.1=client,DNS.2=test.openamepere.com,IP.1=192.168.1.2")
 
+createCert("test.openampere.com", "/CN=Test/", "testpassword", True, "DNS:client,DNS:test.openamepere.com,IP:192.168.2.2")
+print ""
+
+c1 = createCert("client.openampere.com", "/CN=Client/", "clientpassword", False, "")
+print ""
+
+createCert("client2.openampere.com", "/DC=com/DC=openampere/DC=test/CN=Client2", "client2password", False, "")
+print ""
+
+s2 = createCert("test2.openampere.com", "/CN=Test 2", "test2password", True, "DNS:client,DNS:test.openamepere.com,IP:192.168.2.2")
+print ""
+#
+keytool = Keytool(cadir, "test2.openampere.com", "test2password", "", "keystore","test2password")
+print ""
+print keytool.build_trust_store()
+
+print "Validating keytool config"
+print keytool.validate()
+
+keytool = Keytool(cadir, "client2.openampere.com", "client2password", [ "test2.openampere.com" ], "truststore","client2password")
+print keytool.build_trust_store()
+print ""
 print line
-print "Removing cert for client.openampere.com"
-c1.remove_certificate()
 
-print line
-print "Removing cert for test2.openampere.com"
-s2.remove_certificate()
-
-keytool = Keytool(cadir, "client2.openampere.com", "abc123!@#`902", [ "test.openampere.com" ])
-
-print line
 print "Validating keytool config"
 print keytool.validate()
 
@@ -52,4 +61,12 @@ print keytool.build_trust_store()
 print line
 print "Removing truststore"
 #print keytool.remove_trust_store()
+
+print line
+print "Removing cert for client.openampere.com"
+c1.remove_certificate()
+
+print line
+print "Removing cert for test2.openampere.com"
+s2.remove_certificate()
 


### PR DESCRIPTION
- Fixed issue with code running on non max with debug logging on
- Updated documentation with:
  - Subject Alternative Name
  - keytool documentation
  - creating server keystores
- Added key hash symlink on creation of a ca
- Fixed an issue with user certificates issuing CA
- Fixed an issue where relative paths for cadir did not create the correct references
- Removed host to trust as a required element for certtype=keystore
